### PR TITLE
Updates for Clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,30 @@ Finally, the living documentation includes log messages that are useful for deve
 ## Set up and run this project  
 * Ensure you have a [Git client](https://git-scm.com/downloads) and [Gradle](https://gradle.org/) installed (or use via your IDE or other tools)
 * Install [Firefox](https://www.mozilla.org/en-US/firefox/new/).  The default browser used in this demo project is Firefox.
+* Install [Chrome](https://www.google.com/chrome/).  Used for at least one test.
 * `cd` to a relevant folder
 * `git clone https://github.com/concordion/cubano-demo.git` or download and unzip this project
 * Import as a Gradle project into your IDE
+
+## A note on Configuration Files
+The default configuration for this project is pulled from `config.properties`.  Default configuration can be overriden by introducing a `user.properties` file.  Simply override properties in `user.properties` as required (useful for multi developer teams).  The project supplies a `user.properties.template` which can be used for this purpose.
+
+## A note on Browsers
+By default this project is set up to use the Firefox browser (with the Switch Browser fixture additionally using Chrome).
+
+The property `webdriver.browserprovider`, in config.properties controls the default browser (e.g. `webdriver.browserprovider = FirefoxBrowserProvider`).
+
+To modify the default browser, update property `webdriver.browserprovider` in either:
+* the config.properties file
+* or the user.properties file
+
+Additional `[BrowserName]BrowserProviders` can be found in package `org.concordion.cubano.driver.web.provider.*`. 
+
+Two other important classes to review are:
+* `org.concordion.cubano.driver.web.config.WebDriverConfig` > Reads and supplies properties from the config.properties file that is required by the framework
+* `org.concordion.cubano.driver.web.provider.LocalBrowserProvider` > Base class for local browser providers.
+
+Further information on browser support and configuration can be found in the [Cubano documentation on Browser Providers](https://concordion.org/cubano/browser/providers)
 
 ## To Execute Tests
 Concordion fixtures use the JUnit library, with a specialised ConcordionRunner (`@RunWith(ConcordionRunner.class)`).  This annotation is part of the class hierarchy from `ConcordionIndex` or `ConcordionFixture`, which all Fixtures inherit from.
@@ -63,7 +84,13 @@ If working from behind a proxy, then you will need to manage some proxy configur
 For an initial example, see `gradle.properies`, in the root directory, and update the `systemProp.*` parameters as required. For additional configuration options see [accessing the web via a proxy](https://docs.gradle.org/current/userguide/build_environment.html#sec:accessing_the_web_via_a_proxy).
 
 ### Service and Browser Testing
-For an initial example, see `config.properies`, in the root directory, and update the `proxy.*` parameters as required. You must set `proxy.required = true` to use any format of proxy configuration. For additional configuration options see `org.concordion.cubano.config.ProxyConfig`
+For an initial example, see `config.properies`, in the root directory, and update the `proxy.*` parameters as required. You must set `proxy.required = true` to use any format of proxy configuration. 
+
+The built in Cubano class `org.concordion.cubano.config.ProxyConfig`, provides three forms of Proxy Management (choose one):
+* Setting the Proxy from a Config File (which is the mechanism in this project - see below)
+* Setting the Proxy from System Properties
+* Setting the Proxy from  Environment Variables
+
 
 ### With Eclipse
 `Eclipse > Window > Preferences > General > Network Connections`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Complement the examples in this project, with a read of:
 
 Once you are ready to start writing your own tests, pull down the [Cubano Template](https://github.com/concordion/cubano-template) project and adapt this base to start automating your project.
 
-## Features  <TODO fix links in this section when they are available>
+## Features
 
 A goal of Cubano is to generate living documentation that is applicable to a wide audience.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Finally, the living documentation includes log messages that are useful for deve
 * Install [Chrome](https://www.google.com/chrome/).  Used for at least one test.
 * `cd` to a relevant folder
 * `git clone https://github.com/concordion/cubano-demo.git` or download and unzip this project
-* Import as a Gradle project into your IDE
+* Import as a Gradle project into your IDE (e.g. for Eclipse, ensure [Buildship](http://www.eclipse.org/buildship) is installed, then File > Import > Gradle > Existing Gradle Project > follow the wizard)
 
 ## A note on Configuration Files
 The default configuration for this project is pulled from `config.properties`.  Default configuration can be overriden by introducing a `user.properties` file.  Simply override properties in `user.properties` as required (useful for multi developer teams).  The project supplies a `user.properties.template` which can be used for this purpose.
@@ -73,7 +73,8 @@ Concordion fixtures use the JUnit library, with a specialised ConcordionRunner (
 * Class `Example` will run the full suite.  Run as per any standard JUnit fixture.
 * Classes that end with `*Fixture` can be executed in the same way
 
-### From the command line, with the recommended method first:
+### From the command, with the recommended method first. 
+Ensure you are in the `cubano-demo` root directory.
 * `gradlew clean test -Dtest.single=example/Example -Dlogback.configurationFile=logback-jenkins.xml` (runs a single test, which co-ordinates the test suite)
 * `gradlew clean test` (runs all tests in the suite individually)
 

--- a/src/test/resources/example/concordion/ConcordionPresentation.md
+++ b/src/test/resources/example/concordion/ConcordionPresentation.md
@@ -1,5 +1,13 @@
 # Concordion Presentation
 
+## Helpful Hints
+* The Storyboard dropdown, below the example, shows screenshots of the Concordion Presentation. Hovering over each screenshot will turn the screenshot into a tooltip.
+* The Log File link at the top right of the example, contains log file info from the example execution
+* The bottom right of the page contains the information on how long the example took to execute and when it did so
+* The top of the page contains breadcrumb navigation
+
+These are all items provided by Cubano.  Now onto the Concordion Presentation.
+
 As a test automation engineer who is new to Concordion
 I need to find information on Concordion
 So that I can understand what it is and how to use it
@@ -8,3 +16,4 @@ So that I can understand what it is and how to use it
 Given I have opened the Concordion Presentation at __[ ] (- "c:echo=getConcordionPressoURL()")__
 Then I can find information on what [Concordion is and how to use it](- "loadDoco()")
 And if I want to, I can open __[ ] (- "c:echo=getConcordionPressoURL()")__ myself, and navigate to the additional material
+

--- a/src/test/resources/example/concordion/ConcordionPresentation.md
+++ b/src/test/resources/example/concordion/ConcordionPresentation.md
@@ -6,14 +6,9 @@
 * The bottom right of the page contains the information on how long the example took to execute and when it did so
 * The top of the page contains breadcrumb navigation
 
-These are all items provided by Cubano.  Now onto the Concordion Presentation.
-
-As a test automation engineer who is new to Concordion
-I need to find information on Concordion
-So that I can understand what it is and how to use it
+These are all extensions provided by Cubano.  Now onto the Concordion Presentation.
 
 ## [Concordion Presentation](-)
-Given I have opened the Concordion Presentation at __[ ] (- "c:echo=getConcordionPressoURL()")__
-Then I can find information on what [Concordion is and how to use it](- "loadDoco()")
-And if I want to, I can open __[ ] (- "c:echo=getConcordionPressoURL()")__ myself, and navigate to the additional material
+The Concordion Presentation at __[ ] (- "c:echo=getConcordionPressoURL()")__ contains some really useful information  on what [Concordion is and how to use it](- "loadDoco()")
+
 

--- a/user.properties.template
+++ b/user.properties.template
@@ -9,3 +9,6 @@ AnotherEnvironment.searchUrl = https://www.google.co.nz
 #AnotherEnvironment.databaseUrl = jdbc:oracle:thin:[username]/[password]@//[servername]:[port]/[SID]
 AnotherEnvironment.databaseUrl = jdbc:mysql://[servername]:[port]/[database]?user=[username]&password=[password]
 AnotherEnvironment.databaseSchema = SchemaName
+
+
+webdriver.browserprovider = ChromeBrowserProvider


### PR DESCRIPTION
1. Update to concordionPresentation > wordsmith spec to align with purpose.  Added helpful hints on items provided by Cubano.

2. Added an example property for overriding the default browser setting in user.properties.template

3. Updated readme to assist with info on how to update the default browser, as well as feedback from users  as to readability > for setup