### PR TITLE
Refactor data cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // TODO remove Jitpack.io from repositories when upgrading to new  cubano-concordion version.
     testCompile 'org.concordion:concordion:2.2.0'
 //    testCompile 'org.concordion:cubano-concordion:0.2.2'
-    testCompile 'com.github.nigelcharman.cubano:cubano-concordion:log-listener-SNAPSHOT'
+    testCompile 'com.github.concordion.cubano:cubano-concordion:refactor-data-cleanup-SNAPSHOT'
 //    implementation 'com.github.concordion:cubano-concordion:master-SNAPSHOT'
 
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'

--- a/src/test/java/example/CubanoDemoFixture.java
+++ b/src/test/java/example/CubanoDemoFixture.java
@@ -1,14 +1,10 @@
 package example;
 
 import ch.qos.logback.classic.Level;
-import org.concordion.api.*;
 import org.concordion.api.extension.Extension;
-import org.concordion.cubano.data.DataCleanupHelper;
 import org.concordion.cubano.framework.ConcordionFixture;
 import org.concordion.ext.LogbackLogMessenger;
 import org.concordion.ext.LoggingTooltipExtension;
-import org.concordion.slf4j.ext.ReportLogger;
-import org.concordion.slf4j.ext.ReportLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/example/CubanoDemoFixtureLogger.java
+++ b/src/test/java/example/CubanoDemoFixtureLogger.java
@@ -1,23 +1,18 @@
 package example;
 
-import org.concordion.api.BeforeExample;
-import org.concordion.api.BeforeSpecification;
-import org.concordion.api.ExampleName;
 import org.concordion.cubano.framework.ConcordionBase;
-import org.concordion.cubano.framework.FixtureLogger;
+import org.concordion.cubano.framework.fixture.FixtureLogger;
 import org.slf4j.Logger;
 
 public class CubanoDemoFixtureLogger extends FixtureLogger {
     @Override
-    public final void beforeSpecification(Class<? extends ConcordionBase> aClass,
-                                           Logger logger) {
-        logger.info("Initialising the acceptance test class {} on thread {}", getRelativeTestClassName(), Thread.currentThread().getName());
+    public final void beforeSpecification(Class<? extends ConcordionBase> aClass, Logger logger) {
+        logger.info("Initialising the acceptance test class {} on thread {}", getRelativeTestClassName(aClass), Thread.currentThread().getName());
     }
 
     @Override
-    public final void beforeExample(Class<? extends ConcordionBase> aClass,
-            @ExampleName String exampleName, Logger logger) {
-        logger.info("Starting example {} for test fixture {}", exampleName, getRelativeTestClassName());
+    public final void beforeExample(Class<? extends ConcordionBase> aClass, String exampleName, Logger logger) {
+        logger.info("Starting example {} for test fixture {}", exampleName, getRelativeTestClassName(aClass));
     }
 
     @Override
@@ -25,8 +20,8 @@ public class CubanoDemoFixtureLogger extends FixtureLogger {
         logger.info("Finishing example {}", exampleName);
     }
 
-    private String getRelativeTestClassName() {
+    private String getRelativeTestClassName(Class<? extends ConcordionBase> aClass) {
         // This is the name that can be given to the RunSingleTest job in Jenkins
-        return this.getClass().getName().replace(CubanoDemoBrowserFixture.class.getPackage().getName() + ".", "");
+        return aClass.getName().replace(CubanoDemoBrowserFixture.class.getPackage().getName() + ".", "");
     }
 }

--- a/src/test/java/example/CubanoDemoIndex.java
+++ b/src/test/java/example/CubanoDemoIndex.java
@@ -2,7 +2,6 @@ package example;
 
 import org.concordion.api.ConcordionResources;
 import org.concordion.api.FailFast;
-import org.concordion.api.extension.Extensions;
 import org.concordion.cubano.framework.ConcordionBase;
 
 /**

--- a/src/test/java/example/cubanocore/DataManagementFixture.java
+++ b/src/test/java/example/cubanocore/DataManagementFixture.java
@@ -1,56 +1,54 @@
 package example.cubanocore;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import example.CubanoDemoFixture;
+import org.codejargon.fluentjdbc.api.FluentJdbcException;
+import org.concordion.cubano.framework.resource.ResourceScope;
+import org.concordion.cubano.template.driver.database.DataManagementDatabase;
+import org.concordion.cubano.template.driver.domain.AbcDomainData;
+import org.concordion.cubano.template.driver.services.AbcService;
 
 import java.sql.SQLException;
 import java.util.UUID;
 
-import example.CubanoDemoBrowserFixture;
-import org.concordion.cubano.template.driver.database.DataManagementDatabase;
-import org.concordion.cubano.template.driver.domain.AbcDomainData;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
-import org.concordion.cubano.template.driver.workflow.Workflow;
+public class DataManagementFixture extends CubanoDemoFixture {
 
-public class DataManagementFixture extends CubanoDemoBrowserFixture {
-
-    private Workflow workflow = null;
     private DataManagementDatabase database = new DataManagementDatabase();
+    private AbcService abcService = new AbcService();
+    private static AbcDomainData domainData;
 
-    private void initiliaseDB() throws SQLException {
+    private void initialiseDB() throws SQLException {
         database.initialiseDatabase();
     }
 
-    public boolean manageDataSetUpAndTearDown() throws SQLException {
-
+    public void insertData() throws SQLException {
         // Only here for the test setup. Would normally exist as part of the SUT
-        initiliaseDB();
+        initialiseDB();
 
-        AbcDomainData expectedDomainData = new AbcDomainData();
-        expectedDomainData.setDomainDataId(UUID.randomUUID().toString());
-        expectedDomainData.setNameOfTheDomain("AbcDomain");
+        domainData = new AbcDomainData();
+        domainData.setDomainDataId(UUID.randomUUID().toString());
+        domainData.setNameOfTheDomain("AbcDomain");
 
         // Initiate your service
-        workflowUsingDataCleanupHelper().addDataToServiceAndRegisterServiceOnCleanUp(expectedDomainData).submitDomainScenario();
-
-        // Check is in the DB
-        AbcDomainData actualDomainData = database.findAbcDomainUsing(expectedDomainData);
-        assertThat(actualDomainData.getDomainDataId(), is(expectedDomainData.getDomainDataId()));
-
-        // Do what you need to do
-        // Execute test scenarios
-
-        // Clean up happens in CubanoDemoBrowserFixture @ afterExample
-
-
-        return true;
+        abcService.setAbcDomainData(domainData);
+        abcService.submitDomainScenario();
     }
 
-    private Workflow workflowUsingDataCleanupHelper() {
-        if (workflow == null) {
-            workflow = new Workflow(this, getCleanupService());
-        }
+    public boolean existsInDatabase() throws SQLException {
+        try {
+            // Check is in the DB
+            AbcDomainData actualDomainData = database.findAbcDomainUsing(domainData);
+            assertThat(actualDomainData.getDomainDataId(), is(domainData.getDomainDataId()));
 
-        return workflow;
+            return true;
+        } catch(FluentJdbcException e) {
+            return false;
+        }
+    }
+
+    public void registerCloseableResource() {
+        registerCloseableResource(abcService, ResourceScope.EXAMPLE);
     }
 }

--- a/src/test/java/example/cubanocore/UserPoolFixture.java
+++ b/src/test/java/example/cubanocore/UserPoolFixture.java
@@ -1,12 +1,11 @@
 package example.cubanocore;
 
+import example.CubanoDemoFixture;
 import org.concordion.cubano.template.driver.domain.Role;
 import org.concordion.cubano.template.driver.domain.User;
-
-import example.CubanoDemoBrowserFixture;
 import org.concordion.cubano.template.driver.domain.UserPool;
 
-public class UserPoolFixture extends CubanoDemoBrowserFixture {
+public class UserPoolFixture extends CubanoDemoFixture {
 
     private User user;
     private UserPool userPoolManager;
@@ -49,7 +48,7 @@ public class UserPoolFixture extends CubanoDemoBrowserFixture {
 
     public UserPool userPool() {
         if (userPoolManager == null) {
-            userPoolManager = UserPool.createManager(getCleanupService());
+            userPoolManager = UserPool.createManager(this);
         }
 
         return userPoolManager;

--- a/src/test/java/org/concordion/cubano/template/driver/domain/UserPool.java
+++ b/src/test/java/org/concordion/cubano/template/driver/domain/UserPool.java
@@ -1,19 +1,21 @@
 package org.concordion.cubano.template.driver.domain;
 
+import org.concordion.cubano.data.EntityPool;
+import org.concordion.cubano.framework.resource.ResourceRegistry;
+import org.concordion.cubano.framework.resource.ResourceScope;
+import org.concordion.slf4j.ext.ReportLogger;
+import org.concordion.slf4j.ext.ReportLoggerFactory;
+
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.concordion.cubano.data.DataCleanupHelper;
-import org.concordion.cubano.data.EntityPool;
-import org.concordion.slf4j.ext.ReportLogger;
-import org.concordion.slf4j.ext.ReportLoggerFactory;
-
 /**
  * Supplies a pool of Users available for test automation and manages usage.
  */
-public class UserPool extends EntityPool<User> {
+public class UserPool extends EntityPool<User> implements Closeable {
 
     private final ReportLogger logger = ReportLoggerFactory.getReportLogger(this.getClass().getName());
 
@@ -42,22 +44,13 @@ public class UserPool extends EntityPool<User> {
 
     /**
      * Factory method to create new manager user pool manager.
-     * 
-     * @return
-     */
-    public static UserPool createManager() {
-        return new UserPool();
-    }
-
-    /**
-     * Factory method to create new manager user pool manager.
      *
-     * @param cleanupService Provide data cleanup service to register with to automatically cleanup any requested users
      * @return
+     * @param resourceRegistry
      */
-    public static UserPool createManager(DataCleanupHelper cleanupService) {
+    public static UserPool createManager(ResourceRegistry resourceRegistry) {
         UserPool userPool = new UserPool();
-        cleanupService.register(userPool);
+        resourceRegistry.registerCloseableResource(userPool, ResourceScope.EXAMPLE);
 
         return userPool;
     }
@@ -129,13 +122,13 @@ public class UserPool extends EntityPool<User> {
     }
 
     @Override
-    public void cleanup() {
+    public void close() {
         // Do not need to override this method, simply done to enable logging for example
         // Shows how clean up works.
         logger.debug("Before clean up");
         logUserInfo();
 
-        super.cleanup();
+        super.close();
 
         logger.debug("After clean up");
         logUserInfo();

--- a/src/test/java/org/concordion/cubano/template/driver/services/AbcService.java
+++ b/src/test/java/org/concordion/cubano/template/driver/services/AbcService.java
@@ -1,29 +1,28 @@
 package org.concordion.cubano.template.driver.services;
 
-import java.sql.SQLException;
-
-import org.concordion.cubano.data.DataCleanup;
 import org.concordion.cubano.template.driver.database.DataManagementDatabase;
 import org.concordion.cubano.template.driver.domain.AbcDomainData;
 import org.concordion.slf4j.ext.ReportLogger;
 import org.concordion.slf4j.ext.ReportLoggerFactory;
 
-public class AbcService implements DataCleanup {
+import java.io.Closeable;
+import java.sql.SQLException;
+
+public class AbcService implements Closeable {
 
     private final ReportLogger logger = ReportLoggerFactory.getReportLogger(this.getClass().getName());
     private DataManagementDatabase database = new DataManagementDatabase();
     private AbcDomainData abcDomainData;
 
-    public AbcService(AbcDomainData abcDomainData) {
-        this.abcDomainData = abcDomainData;
-    }
-
     public AbcDomainData getAbcDomainData() {
         return abcDomainData;
     }
+    public void setAbcDomainData(AbcDomainData domainData) {
+        abcDomainData = domainData;
+    }
 
     @Override
-    public void cleanup() {
+    public void close() {
 
         logger.debug("Before clean up");
 

--- a/src/test/java/org/concordion/cubano/template/driver/workflow/Workflow.java
+++ b/src/test/java/org/concordion/cubano/template/driver/workflow/Workflow.java
@@ -1,25 +1,15 @@
 package org.concordion.cubano.template.driver.workflow;
 
-import org.concordion.cubano.data.DataCleanupHelper;
 import org.concordion.cubano.driver.BrowserBasedTest;
-import org.concordion.cubano.template.driver.domain.AbcDomainData;
-import org.concordion.cubano.template.driver.services.AbcService;
 import org.concordion.cubano.template.driver.services.ExampleRestApi;
 import org.concordion.cubano.template.driver.ui.concordion.ConcordionPresentationPage;
 import org.concordion.cubano.template.driver.ui.google.GoogleSearchPage;
 
 public class Workflow {
     private final BrowserBasedTest test;
-    private DataCleanupHelper dataCleanup = null;
-
 
     public Workflow(BrowserBasedTest test) {
         this.test = test;
-    }
-
-    public Workflow(BrowserBasedTest test, DataCleanupHelper dataHelper) {
-        this.test = test;
-        this.dataCleanup = dataHelper;
     }
 
     public GoogleSearchPage openSearch() {
@@ -33,12 +23,4 @@ public class Workflow {
     public ExampleRestApi restExample() {
         return new ExampleRestApi();
     }
-
-    public AbcService addDataToServiceAndRegisterServiceOnCleanUp(AbcDomainData abcDomainData) {
-        AbcService abcService = new AbcService(abcDomainData);
-//        dataCleanup.register(abcService);
-
-        return abcService;
-    }
-
 }

--- a/src/test/resources/example/cubanocore/DataManagement.md
+++ b/src/test/resources/example/cubanocore/DataManagement.md
@@ -1,9 +1,16 @@
-# Demonstrates the use of the `DataCleanup` interface.  
+# Demonstrates the use of the `ResourceRegistry` interface.  
 
 View the comments inside `DataManagementFixture` and the entries in the `Log File` (top right of each example below), to follow along with the management of the test data.
 
-## [Cubano Registration service for data cleanup](-)
-Given data has been set up as part of my test fixture
-When the fixture completes
-Then the data is managed (e.g. cleaned up, completed etc) as part of the [Cubano Registration service for data cleanup](- "c:assertTrue=manageDataSetUpAndTearDown()")
+_Note that we do not encourage chaining examples as per this test, 
+but checking in the 2nd example is the only way to demonstrate that data was cleaned up when the first example finished._
 
+## [Insert data and register a closeable service](-)
+Given I have [registered a closeable service that cleans up the database at example scope](- "registerCloseableResource()")
+When I [insert data](- "insertData()")
+Then the [data exists in the database](- "c:assertTrue=existsInDatabase()") (and will be subsequently cleaned up once this example finishes) 
+
+## [Data is cleaned up in subsequent example](-)
+Given data was inserted in the previous example with a closeable service at example scope
+When this example executes
+Then the data [does not exist in the database](- "c:assertFalse=existsInDatabase()").

--- a/src/test/resources/example/cubanocore/UserPool.md
+++ b/src/test/resources/example/cubanocore/UserPool.md
@@ -1,4 +1,4 @@
-# Demonstrates the use of the `EntityPool` class and the `DataCleanup` interface.
+# Demonstrates the use of the `EntityPool` class and the `ResourceRegistry` interface.
 
 View the `Log File` (top right of each example below), to follow along with the management of the users.
 


### PR DESCRIPTION
To be applied after PR#8. Until merged, changes specific to this PR can be viewed at https://github.com/concordion/cubano-demo/compare/log-listener...refactor-data-cleanup.

Some things to look at specifically are:
`CubanoDemoBrowserFixture`:
* the resource is being registered at EXAMPLE scope, so it won't get cleaned after the specification, but will be on each example of the specification
* the [cleanup routine](https://github.com/concordion/cubano-demo/compare/log-listener...refactor-data-cleanup#diff-490d669a300494c220588e9830d393e7R62) is now being called for each registered resource, rather than once for all resources. I don't think this will have much impact, since we'll just be toggling the storyboard cards on and off more often, and will have extra logging, if there are multiple resources

