### PR TITLE
Move cubano dependency back to master, re-instate datacleanup helper in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,9 @@ dependencies {
     // TODO remove Jitpack.io from repositories when upgrading to new  cubano-concordion version.
     testCompile 'org.concordion:concordion:2.2.0'
 //    testCompile 'org.concordion:cubano-concordion:0.2.2'
-    testCompile 'com.github.concordion.cubano:cubano-concordion:log-listener-SNAPSHOT'
+    //testCompile 'com.github.concordion.cubano:cubano-concordion:log-listener-SNAPSHOT'
 
-//    implementation 'com.github.concordion:cubano-concordion:master-SNAPSHOT'
+    testCompile 'com.github.concordion.cubano:cubano-concordion:master-SNAPSHOT'
 
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'
     

--- a/src/test/java/example/CubanoDemoBrowserFixture.java
+++ b/src/test/java/example/CubanoDemoBrowserFixture.java
@@ -1,6 +1,15 @@
 package example;
 
-import org.concordion.api.*;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import org.concordion.api.AfterExample;
+import org.concordion.api.AfterSpecification;
+import org.concordion.api.ConcordionResources;
+import org.concordion.api.ConcordionScoped;
+import org.concordion.api.FailFast;
+import org.concordion.api.Scope;
+import org.concordion.api.ScopedObjectHolder;
 import org.concordion.api.extension.Extension;
 import org.concordion.cubano.config.Config;
 import org.concordion.cubano.config.ProxyConfig;
@@ -11,9 +20,6 @@ import org.concordion.cubano.framework.ConcordionBrowserFixture;
 import org.concordion.cubano.template.AppConfig;
 import org.concordion.slf4j.ext.ReportLogger;
 import org.concordion.slf4j.ext.ReportLoggerFactory;
-
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 
 /**
  * Customises the test specification and provides some helper methods

--- a/src/test/java/example/CubanoDemoFixture.java
+++ b/src/test/java/example/CubanoDemoFixture.java
@@ -1,16 +1,13 @@
 package example;
 
-import ch.qos.logback.classic.Level;
-import org.concordion.api.*;
 import org.concordion.api.extension.Extension;
-import org.concordion.cubano.data.DataCleanupHelper;
 import org.concordion.cubano.framework.ConcordionFixture;
 import org.concordion.ext.LogbackLogMessenger;
 import org.concordion.ext.LoggingTooltipExtension;
-import org.concordion.slf4j.ext.ReportLogger;
-import org.concordion.slf4j.ext.ReportLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
 
 /**
  */

--- a/src/test/java/example/CubanoDemoFixtureLogger.java
+++ b/src/test/java/example/CubanoDemoFixtureLogger.java
@@ -1,7 +1,5 @@
 package example;
 
-import org.concordion.api.BeforeExample;
-import org.concordion.api.BeforeSpecification;
 import org.concordion.api.ExampleName;
 import org.concordion.cubano.framework.ConcordionBase;
 import org.concordion.cubano.framework.FixtureLogger;

--- a/src/test/java/example/CubanoDemoIndex.java
+++ b/src/test/java/example/CubanoDemoIndex.java
@@ -2,7 +2,6 @@ package example;
 
 import org.concordion.api.ConcordionResources;
 import org.concordion.api.FailFast;
-import org.concordion.api.extension.Extensions;
 import org.concordion.cubano.framework.ConcordionBase;
 
 /**

--- a/src/test/java/example/commands/EmbedFormattedDataFixture.java
+++ b/src/test/java/example/commands/EmbedFormattedDataFixture.java
@@ -1,10 +1,11 @@
 package example.commands;
 
-import example.CubanoDemoFixture;
 import org.concordion.api.extension.Extensions;
 import org.concordion.api.option.ConcordionOptions;
 import org.concordion.cubano.template.driver.util.TableBuilder;
 import org.concordion.ext.EmbedExtension;
+
+import example.CubanoDemoFixture;
 
 @Extensions({ EmbedExtension.class })
 @ConcordionOptions(declareNamespaces = { "ext", "urn:concordion-extensions:2010" })

--- a/src/test/java/example/commands/VerifyRowsFixture.java
+++ b/src/test/java/example/commands/VerifyRowsFixture.java
@@ -1,10 +1,11 @@
 package example.commands;
 
-import example.CubanoDemoFixture;
-import org.concordion.api.MultiValueResult;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.concordion.api.MultiValueResult;
+
+import example.CubanoDemoFixture;
 
 public class VerifyRowsFixture extends CubanoDemoFixture {
 

--- a/src/test/java/example/concordion/ConcordionPresentationFixture.java
+++ b/src/test/java/example/concordion/ConcordionPresentationFixture.java
@@ -1,9 +1,9 @@
 package example.concordion;
 
-import example.CubanoDemoBrowserFixture;
 import org.concordion.cubano.template.AppConfig;
-
 import org.concordion.cubano.template.driver.workflow.Workflow;
+
+import example.CubanoDemoBrowserFixture;
 
 public class ConcordionPresentationFixture extends CubanoDemoBrowserFixture {
     private Workflow workflow = new Workflow(this);

--- a/src/test/java/example/cubanoconcordion/ExceptionHtmlCaptureExtensionFixture.java
+++ b/src/test/java/example/cubanoconcordion/ExceptionHtmlCaptureExtensionFixture.java
@@ -1,7 +1,8 @@
 package example.cubanoconcordion;
 
-import example.CubanoDemoBrowserFixture;
 import org.concordion.cubano.template.driver.workflow.Workflow;
+
+import example.CubanoDemoBrowserFixture;
 
 public class ExceptionHtmlCaptureExtensionFixture extends CubanoDemoBrowserFixture {
     private Workflow workflow = new Workflow(this);

--- a/src/test/java/example/cubanocore/DataLoadersFixture.java
+++ b/src/test/java/example/cubanocore/DataLoadersFixture.java
@@ -1,9 +1,7 @@
 package example.cubanocore;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import example.CubanoDemoBrowserFixture;
-import example.CubanoDemoFixture;
+import java.io.IOException;
+
 import org.concordion.cubano.data.JsonLoader;
 import org.concordion.cubano.driver.http.JsonReader;
 import org.concordion.cubano.template.driver.domain.User;
@@ -14,7 +12,10 @@ import org.concordion.slf4j.ext.MediaType;
 import org.concordion.slf4j.ext.ReportLogger;
 import org.concordion.slf4j.ext.ReportLoggerFactory;
 
-import java.io.IOException;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import example.CubanoDemoFixture;
 
 public class DataLoadersFixture extends CubanoDemoFixture {
 

--- a/src/test/java/example/cubanocore/DataManagementFixture.java
+++ b/src/test/java/example/cubanocore/DataManagementFixture.java
@@ -6,11 +6,11 @@ import static org.junit.Assert.assertThat;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import example.CubanoDemoBrowserFixture;
 import org.concordion.cubano.template.driver.database.DataManagementDatabase;
 import org.concordion.cubano.template.driver.domain.AbcDomainData;
-
 import org.concordion.cubano.template.driver.workflow.Workflow;
+
+import example.CubanoDemoBrowserFixture;
 
 public class DataManagementFixture extends CubanoDemoBrowserFixture {
 

--- a/src/test/java/example/cubanocore/UserPoolFixture.java
+++ b/src/test/java/example/cubanocore/UserPoolFixture.java
@@ -2,9 +2,9 @@ package example.cubanocore;
 
 import org.concordion.cubano.template.driver.domain.Role;
 import org.concordion.cubano.template.driver.domain.User;
+import org.concordion.cubano.template.driver.domain.UserPool;
 
 import example.CubanoDemoBrowserFixture;
-import org.concordion.cubano.template.driver.domain.UserPool;
 
 public class UserPoolFixture extends CubanoDemoBrowserFixture {
 

--- a/src/test/java/example/cubanohttpeasy/HttpEasyGetFixture.java
+++ b/src/test/java/example/cubanohttpeasy/HttpEasyGetFixture.java
@@ -1,7 +1,12 @@
 package example.cubanohttpeasy;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import example.CubanoDemoBrowserFixture;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+
+import java.io.IOException;
+
 import org.concordion.cubano.driver.http.HttpEasy;
 import org.concordion.cubano.driver.http.JsonReader;
 import org.concordion.cubano.template.driver.logger.TestLoggerLogWriter;
@@ -13,9 +18,9 @@ import org.concordion.slf4j.ext.ReportLogger;
 import org.concordion.slf4j.ext.ReportLoggerFactory;
 import org.junit.Rule;
 
-import java.io.IOException;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import example.CubanoDemoBrowserFixture;
 
 public class HttpEasyGetFixture extends CubanoDemoBrowserFixture {
 

--- a/src/test/java/example/cubanohttpeasy/HttpEasyPostFixture.java
+++ b/src/test/java/example/cubanohttpeasy/HttpEasyPostFixture.java
@@ -7,7 +7,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 
 import java.io.IOException;
 
-import example.CubanoDemoBrowserFixture;
 import org.concordion.cubano.driver.http.HttpEasy;
 import org.concordion.cubano.driver.http.JsonReader;
 import org.concordion.cubano.template.driver.logger.TestLoggerLogWriter;
@@ -20,6 +19,8 @@ import org.junit.Rule;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.net.MediaType;
+
+import example.CubanoDemoBrowserFixture;
 
 public class HttpEasyPostFixture extends CubanoDemoBrowserFixture {
 

--- a/src/test/java/example/cubanowebdriver/SwitchBrowser.java
+++ b/src/test/java/example/cubanowebdriver/SwitchBrowser.java
@@ -2,11 +2,11 @@ package example.cubanowebdriver;
 
 import java.io.IOException;
 
-import example.CubanoDemoBrowserFixture;
 import org.concordion.cubano.driver.web.Browser;
 import org.concordion.cubano.driver.web.provider.ChromeBrowserProvider;
-
 import org.concordion.cubano.template.driver.workflow.Workflow;
+
+import example.CubanoDemoBrowserFixture;
 
 public class SwitchBrowser extends CubanoDemoBrowserFixture {
     private Workflow workflow = new Workflow(this);

--- a/src/test/java/example/google/SearchForConcordionFixture.java
+++ b/src/test/java/example/google/SearchForConcordionFixture.java
@@ -1,7 +1,8 @@
 package example.google;
 
-import example.CubanoDemoBrowserFixture;
 import org.concordion.cubano.template.driver.workflow.Workflow;
+
+import example.CubanoDemoBrowserFixture;
 
 public class SearchForConcordionFixture extends CubanoDemoBrowserFixture {
     private Workflow workflow = new Workflow(this);

--- a/src/test/java/example/service/RestRequestFixture.java
+++ b/src/test/java/example/service/RestRequestFixture.java
@@ -1,9 +1,10 @@
 package example.service;
 
-import example.CubanoDemoBrowserFixture;
+import java.io.IOException;
+
 import org.concordion.cubano.template.driver.workflow.Workflow;
 
-import java.io.IOException;
+import example.CubanoDemoBrowserFixture;
 
 public class RestRequestFixture extends CubanoDemoBrowserFixture {
     private Workflow workflow = new Workflow(this);

--- a/src/test/java/org/concordion/cubano/template/driver/workflow/Workflow.java
+++ b/src/test/java/org/concordion/cubano/template/driver/workflow/Workflow.java
@@ -10,6 +10,8 @@ import org.concordion.cubano.template.driver.ui.google.GoogleSearchPage;
 
 public class Workflow {
     private final BrowserBasedTest test;
+    
+    //TODO - is this still required ?
     private DataCleanupHelper dataCleanup = null;
 
 
@@ -36,7 +38,7 @@ public class Workflow {
 
     public AbcService addDataToServiceAndRegisterServiceOnCleanUp(AbcDomainData abcDomainData) {
         AbcService abcService = new AbcService(abcDomainData);
-//        dataCleanup.register(abcService);
+        dataCleanup.register(abcService);
 
         return abcService;
     }


### PR DESCRIPTION
Move cubano dependency back to master, re-instate datacleanup helper in workflow, remove unused imports.  The removal of the datacleanup helper may have been related to the following branch update ?

reinstated for now to demonstrate fixture cleanup.