### PR TITLE
Refactor location of HttpEasyConfigurator

### DIFF
--- a/src/test/java/example/CubanoDemoBrowserFixture.java
+++ b/src/test/java/example/CubanoDemoBrowserFixture.java
@@ -9,10 +9,9 @@ import org.concordion.cubano.driver.concordion.ExceptionHtmlCaptureExtension;
 import org.concordion.cubano.framework.ConcordionBrowserFixture;
 import org.concordion.cubano.framework.resource.CloseListener;
 import org.concordion.cubano.framework.resource.ResourceScope;
+import org.concordion.cubano.template.driver.httpeasy.HttpEasyConfigurator;
 import org.concordion.slf4j.ext.ReportLogger;
 import org.concordion.slf4j.ext.ReportLoggerFactory;
-
-import example.cubanohttpeasy.HttpEasyConfigurator;
 
 /**
  * A base class for extension by fixtures that invoke a browser, and may also use HttpEasy.

--- a/src/test/java/example/CubanoDemoFixture.java
+++ b/src/test/java/example/CubanoDemoFixture.java
@@ -1,9 +1,9 @@
 package example;
 
-import example.cubanohttpeasy.HttpEasyConfigurator;
 import org.concordion.api.ConcordionResources;
 import org.concordion.api.FailFast;
 import org.concordion.cubano.framework.ConcordionFixture;
+import org.concordion.cubano.template.driver.httpeasy.HttpEasyConfigurator;
 
 /**
  * A base class for extension by fixtures that contain assertions.

--- a/src/test/java/org/concordion/cubano/template/driver/httpeasy/HttpEasyConfigurator.java
+++ b/src/test/java/org/concordion/cubano/template/driver/httpeasy/HttpEasyConfigurator.java
@@ -1,4 +1,4 @@
-package example.cubanohttpeasy;
+package org.concordion.cubano.template.driver.httpeasy;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;


### PR DESCRIPTION
Moved HttpEasyConfigurator from _example.cubanohttpeasy_  to _org.concordion.cubano.template.driver.httpeasy_