### PR TITLE
Addition of the extensions into Index and Fixture Classes

### DIFF
--- a/src/test/java/org/concordion/cubano/template/framework/CubanoDemoBrowserFixture.java
+++ b/src/test/java/org/concordion/cubano/template/framework/CubanoDemoBrowserFixture.java
@@ -5,11 +5,15 @@ import java.io.Closeable;
 import org.concordion.api.ConcordionResources;
 import org.concordion.api.FailFast;
 import org.concordion.api.extension.Extension;
+import org.concordion.api.extension.Extensions;
 import org.concordion.cubano.driver.concordion.ExceptionHtmlCaptureExtension;
+import org.concordion.cubano.driver.concordion.ExpectedToFailInfoExtension;
 import org.concordion.cubano.framework.ConcordionBrowserFixture;
 import org.concordion.cubano.framework.resource.CloseListener;
 import org.concordion.cubano.framework.resource.ResourceScope;
 import org.concordion.cubano.template.driver.httpeasy.HttpEasyConfigurator;
+import org.concordion.ext.TimestampFormatterExtension;
+import org.concordion.ext.runtotals.RunTotalsExtension;
 import org.concordion.slf4j.ext.ReportLogger;
 import org.concordion.slf4j.ext.ReportLoggerFactory;
 
@@ -22,6 +26,7 @@ import org.concordion.slf4j.ext.ReportLoggerFactory;
  * @see CubanoDemoFixture for fixtures that don't invoke a browser
  */
 @ConcordionResources("/customConcordion.css")
+@Extensions({ TimestampFormatterExtension.class, RunTotalsExtension.class, ExpectedToFailInfoExtension.class })
 @FailFast
 public abstract class CubanoDemoBrowserFixture extends ConcordionBrowserFixture {
     protected final ReportLogger reportLogger = ReportLoggerFactory.getReportLogger(this.getClass().getName());

--- a/src/test/java/org/concordion/cubano/template/framework/CubanoDemoFixture.java
+++ b/src/test/java/org/concordion/cubano/template/framework/CubanoDemoFixture.java
@@ -2,9 +2,13 @@ package org.concordion.cubano.template.framework;
 
 import org.concordion.api.ConcordionResources;
 import org.concordion.api.FailFast;
+import org.concordion.api.extension.Extensions;
+import org.concordion.cubano.driver.concordion.ExpectedToFailInfoExtension;
 import org.concordion.cubano.framework.ConcordionFixture;
 import org.concordion.cubano.template.AppConfig;
 import org.concordion.cubano.template.driver.httpeasy.HttpEasyConfigurator;
+import org.concordion.ext.TimestampFormatterExtension;
+import org.concordion.ext.runtotals.RunTotalsExtension;
 import org.concordion.slf4j.ext.ReportLogger;
 import org.concordion.slf4j.ext.ReportLoggerFactory;
 
@@ -15,6 +19,7 @@ import org.concordion.slf4j.ext.ReportLoggerFactory;
  * @see CubanoDemoBrowserFixture for fixtures that invoke a browser
  */
 @ConcordionResources("/customConcordion.css")
+@Extensions({ TimestampFormatterExtension.class, RunTotalsExtension.class, ExpectedToFailInfoExtension.class })
 @FailFast
 public abstract class CubanoDemoFixture extends ConcordionFixture {
     protected final ReportLogger reportLogger = ReportLoggerFactory.getReportLogger(this.getClass().getName());

--- a/src/test/java/org/concordion/cubano/template/framework/CubanoDemoIndex.java
+++ b/src/test/java/org/concordion/cubano/template/framework/CubanoDemoIndex.java
@@ -1,7 +1,11 @@
 package org.concordion.cubano.template.framework;
 
 import org.concordion.api.ConcordionResources;
+import org.concordion.api.extension.Extensions;
+import org.concordion.cubano.driver.concordion.ExpectedToFailInfoExtension;
 import org.concordion.cubano.framework.ConcordionBase;
+import org.concordion.ext.TimestampFormatterExtension;
+import org.concordion.ext.runtotals.RunTotalsExtension;
 
 /**
  * A base class for extension by fixtures which relate to "index" specifications containing no assertions.
@@ -10,5 +14,6 @@ import org.concordion.cubano.framework.ConcordionBase;
  * @see CubanoDemoBrowserFixture for fixtures that invoke a browser
  */
 @ConcordionResources("/customConcordion.css")
+@Extensions({ TimestampFormatterExtension.class, RunTotalsExtension.class, ExpectedToFailInfoExtension.class })
 public abstract class CubanoDemoIndex extends ConcordionBase {
 }


### PR DESCRIPTION
Do PR #20 first.

Check commentary prior to approving.  The code as submitted works on other projects using Cubano.

These extension annotations originally existed in the 'ConcordionDomainBase' class.  After the hierarchy refactoring this class was removed.  The resolution is to proceed with this PR as indicated in the changed files  or do something like the discussion below ....

Some thoughts from another thread:
_The problem is that we can't delegate, since the extension fields must be on the fixture class.

Default interfaces could work, but aren't supported by Concordion currently. We only check for superclasses, not fields on interfaces.  Need to research more before supporting this in Concordion - it seems like a hack to get multiple inheritance to work and could be a code smell.

Is there some way of having a getExtensions() method that could then be implemented by subclasses to return a list of all extensions? I think this would need a Concordion change too. Would we then need separate getExtensionsForIndex() and getExtensionsForFixtures() methods?

Do we investigate this now (which might need a Concordion release) or defer until a 0.4.0 release?_
